### PR TITLE
Convert root/madhav-migration to GitHub Actions

### DIFF
--- a/.github/workflows/madhav-migration.yml
+++ b/.github/workflows/madhav-migration.yml
@@ -1,0 +1,17 @@
+name: root/madhav-migration
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+jobs:
+  hello_world:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Hello, World!"


### PR DESCRIPTION
Pipeline migrated from [GitLab](http://gitlab-server-alb-958697968.us-east-1.elb.amazonaws.com/root/madhav-migration) :tada: