### PR TITLE
Convert root/madhav-migration to GitHub Actions

### DIFF
--- a/.github/workflows/madhav-migration.yml
+++ b/.github/workflows/madhav-migration.yml
@@ -1,0 +1,7 @@
+name: root/madhav-migration
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true


### PR DESCRIPTION
Pipeline migrated from [GitLab](http://gitlab-server-alb-958697968.us-east-1.elb.amazonaws.com/root/madhav-migration) :tada: